### PR TITLE
bug-fix: `parseLiteral` could not parse normally

### DIFF
--- a/src/Data/RDF/Internal.hs
+++ b/src/Data/RDF/Internal.hs
@@ -26,12 +26,13 @@ import qualified Data.Attoparsec.Text       as A
 
 import Data.Char
 
+import Data.Functor
+
 import Data.String
 
 import GHC.Generics
 
 import qualified Data.Text as T
-import qualified Data.List as L
 
 -- | A contiguous RDF graph with optional label. Note that a contiguous graph
 --   within an RDF data set will not appear as a single contiguous graph to this
@@ -382,24 +383,24 @@ parseLiteralBody = Literal <$> escString <*> valType
           valIRIType  = LiteralIRIType <$> (A.string "^^" *> parseEscapedIRI)
           valLangType = LiteralLangType <$> (A.char '@' *> A.takeWhile1 isLang)
           isLang c    = isAlphaNum c || (c == '-')
-          escString = unescapeAll <$> A.scan False machine <* "\""
-          machine False '\\' = Just True
-          machine False '"'  = Nothing
-          machine False _    = Just False
-          machine True _     = Just False
-          unescapeAll t = case L.uncons $ T.splitOn "\\" t of
-              Just (x, xs) -> x <> T.concat (unescapeFrag xs)
-              Nothing -> t
-          unescapeFrag []     = []
-          unescapeFrag (f:fs) = case T.uncons f of
-                Nothing        -> f : unescapeFrag fs
-                (Just (e, f')) -> T.singleton (unescape e) : f' : unescapeFrag fs
-          unescape 't' = '\t'
-          unescape 'b' = '\b'
-          unescape 'n' = '\n'
-          unescape 'r' = '\r'
-          unescape 'f' = '\f'
-          unescape c   = c
+
+          escString :: A.Parser T.Text
+          escString = T.pack <$> A.manyTill escChar (A.char '"')
+
+          escChar :: A.Parser Char
+          escChar = A.char '\\' *> (unescape <|> pure '\\')
+              <|> A.satisfy (/= '"')
+
+          unescape :: A.Parser Char
+          unescape =
+              (A.char 't' $> '\t')
+              <|> (A.char 'b' $> '\b')
+              <|> (A.char 'n' $> '\n')
+              <|> (A.char 'r' $> '\r')
+              <|> (A.char 'f' $> '\f')
+              <|> (A.char '"' $> '"')
+              <|> (A.char '\\' $> '\\')
+
 
 -- | Parse an RDF 'Literal', including the 'LiteralType' if present.
 parseLiteral :: A.Parser Literal

--- a/src/Data/RDF/Internal.hs
+++ b/src/Data/RDF/Internal.hs
@@ -31,6 +31,7 @@ import Data.String
 import GHC.Generics
 
 import qualified Data.Text as T
+import qualified Data.List as L
 
 -- | A contiguous RDF graph with optional label. Note that a contiguous graph
 --   within an RDF data set will not appear as a single contiguous graph to this
@@ -386,7 +387,9 @@ parseLiteralBody = Literal <$> escString <*> valType
           machine False '"'  = Nothing
           machine False _    = Just False
           machine True _     = Just False
-          unescapeAll = T.concat . unescapeFrag . T.splitOn "\\"
+          unescapeAll t = case L.uncons $ T.splitOn "\\" t of
+              Just (x, xs) -> x <> T.concat (unescapeFrag xs)
+              Nothing -> t
           unescapeFrag []     = []
           unescapeFrag (f:fs) = case T.uncons f of
                 Nothing        -> f : unescapeFrag fs

--- a/src/Data/RDF/Internal.hs
+++ b/src/Data/RDF/Internal.hs
@@ -381,7 +381,7 @@ parseLiteralBody = Literal <$> escString <*> valType
           valIRIType  = LiteralIRIType <$> (A.string "^^" *> parseEscapedIRI)
           valLangType = LiteralLangType <$> (A.char '@' *> A.takeWhile1 isLang)
           isLang c    = isAlphaNum c || (c == '-')
-          escString = unescapeAll <$> A.scan False machine
+          escString = unescapeAll <$> A.scan False machine <* "\""
           machine False '\\' = Just True
           machine False '"'  = Nothing
           machine False _    = Just False


### PR DESCRIPTION
`parseNQuads` could not parse with literal.

```haskell
> parseNQuads "_:a <http://example.com/r> \"litral str\" ."
[Left "'.': Failed reading: satisfy"]
```

and, `parseLiteral` had some bug.

```haskell
> "\"lit\"@en" :: Literal
Literal {litString = "lit", litType = LiteralUntyped}

> "\"n is not \\n\"" :: Literal
Literal {litString = "\n is not \n", litType = LiteralUntyped}

> "\" a \\\\ b \"" :: Literal
Literal {litString = " a  b ", litType = LiteralUntyped}
```

I fixed these.

```haskell
> parseNQuads "_:a <http://example.com/r> \"litral str\" ."
[Right (RDFGraph {rdfLabel = Nothing, rdfTriples = [Triple (BlankSubject (BlankNode {unBlankNode = "a"})) (Predicate {unPredicate = IRI {iriScheme = "http", iriAuth = Just (IRIAuth {iriUser = Nothing, iriHost = "example.com", iriPort = Nothing}), iriPath = "r", iriQuery = Nothing, iriFragment = Nothing}}) (LiteralObject (Literal {litString = "litral str", litType = LiteralUntyped}))]})]

> "\"lit\"@en" :: Literal
Literal {litString = "lit", litType = LiteralLangType "en"}

> "\"n is not \\n\"" :: Literal
Literal {litString = "n is not \n", litType = LiteralUntyped}

> "\" a \\\\ b \"" :: Literal
Literal {litString = " a \\ b ", litType = LiteralUntyped}
```
